### PR TITLE
fix: enforce UTC input and Helsinki-aware school hours validation

### DIFF
--- a/internal/dto/reservation.go
+++ b/internal/dto/reservation.go
@@ -36,6 +36,6 @@ type UserDto struct {
 // CreateReservationRequest is used to create reservation
 type CreateReservationRequest struct {
 	RoomID    int64     `json:"roomId" validate:"required,gt=0"`
-	StartTime time.Time `json:"startTime" validate:"required,futureTime,schoolHours"`
-	EndTime   time.Time `json:"endTime" validate:"required,gtfield=StartTime,schoolHours"`
+	StartTime time.Time `json:"startTime" validate:"required,utc,futureTime,schoolHours"`
+	EndTime   time.Time `json:"endTime" validate:"required,utc,gtfield=StartTime,schoolHours"`
 }

--- a/internal/handler/handler_reservations.go
+++ b/internal/handler/handler_reservations.go
@@ -58,8 +58,8 @@ func (h *Handler) CreateReservation(w http.ResponseWriter, r *http.Request) {
 	respondWithJSON(w, http.StatusCreated, dto.ReservationDto{
 		ID:        reservation.ID,
 		RoomID:    reservation.RoomID,
-		StartTime: reservation.StartTime,
-		EndTime:   reservation.EndTime,
+		StartTime: reservation.StartTime.UTC(),
+		EndTime:   reservation.EndTime.UTC(),
 		CreatedBy: dto.UserDto{
 			ID:   currentUser.ID,
 			Name: currentUser.Name,

--- a/internal/service/reservation.go
+++ b/internal/service/reservation.go
@@ -251,8 +251,8 @@ func (s *ReservationService) GetReservations(
 
 			slots = append(slots, dto.ReservedSlotDto{
 				ID:        res.ID,
-				StartTime: res.StartTime,
-				EndTime:   res.EndTime,
+				StartTime: res.StartTime.UTC(),
+				EndTime:   res.EndTime.UTC(),
 				BookedBy:  bookedBy,
 			})
 		}


### PR DESCRIPTION
## Problem
The API accepted timestamps in any timezone offset, causing two bugs:

1. `schoolHours` validator used `t.Hour()` on the client-submitted offset 
   instead of Helsinki local time — a booking at 4 AM Helsinki could pass 
   validation if the client attached a +04:00 offset
2. API responses reflected the server's local timezone, meaning the response 
   format would change if the server was deployed elsewhere
 
## Changes
- Added `validateUTC` to reject non-UTC timestamps at the request level
- Fixed `validateSchoolHours` to convert to `Europe/Helsinki` before hour check
- Normalized reservation response timestamps to UTC
- Added descriptive error message for the new `utc` validation tag
- Updated tests to use `helsinkiTime` helper and added `TestValidate_UTC`