### PR TITLE
Changed validation of school hours to include 20:00

### DIFF
--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -79,7 +79,8 @@ func validateSchoolHours(fl validator.FieldLevel) bool {
 	}
 
 	hour := t.In(helsinkiTZ).Hour()
-	return hour >= schoolOpenHour && hour < schoolCloseHour
+	minute := t.In(helsinkiTZ).Minute()
+	return hour >= schoolOpenHour && (hour < schoolCloseHour || (hour == schoolCloseHour && minute == 0))
 }
 
 // validateMaxDateRange ensures date range doesn't exceed a maximum (e.g 60 days)

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -41,6 +41,14 @@ func TestValidate_Success(t *testing.T) {
 				EndTime:   helsinkiTime(t, y, m, d, 19, 59),
 			},
 		},
+		{
+			name: "reservation ends exactly as school ends (8:00 PM Helsinki)",
+			input: dto.CreateReservationRequest{
+				RoomID:    3,
+				StartTime: helsinkiTime(t, y, m, d, 18, 0),
+				EndTime:   helsinkiTime(t, y, m, d, 20, 0),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -249,9 +257,9 @@ func TestValidate_SchoolHours(t *testing.T) {
 			errField:  "StartTime",
 		},
 		{
-			name:      "end time too late (8 PM Helsinki)",
+			name:      "end time too late (8:01 PM Helsinki)",
 			startTime: helsinkiTime(t, y, m, d, 18, 0),
-			endTime:   helsinkiTime(t, y, m, d, 20, 0), // 18:00 UTC
+			endTime:   helsinkiTime(t, y, m, d, 20, 1), // 18:01 UTC
 			wantErr:   true,
 			errField:  "EndTime",
 		},
@@ -271,6 +279,12 @@ func TestValidate_SchoolHours(t *testing.T) {
 			name:      "boundary - end at 7:59 PM Helsinki",
 			startTime: helsinkiTime(t, y, m, d, 18, 0),
 			endTime:   helsinkiTime(t, y, m, d, 19, 59), // 17:59 UTC
+			wantErr:   false,
+		},
+		{
+			name:      "boundary - end at 8:00 PM Helsinki",
+			startTime: helsinkiTime(t, y, m, d, 18, 0),
+			endTime:   helsinkiTime(t, y, m, d, 20, 0), // 18:00 UTC
 			wantErr:   false,
 		},
 	}


### PR DESCRIPTION
As the frontend only offers even half hours, disallowing bookings that end at 20:00 meant that you could never book the range 19:30-20:00 at all, which doesn't seem like intended behaviour. 

Also updated the validator tests to include 20:00 as a passing ending time, and changed the failing ending time test to 20:01. I left in the old 19:59 passing tests, but they're technically superfluous now.